### PR TITLE
Exercise 3. Task 1. Unit testing.

### DIFF
--- a/src/Application/tests/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.cs
+++ b/src/Application/tests/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.cs
@@ -4,11 +4,38 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 using RazorPagesTestSample.Data;
+using System.ComponentModel.DataAnnotations;
 
 namespace RazorPagesTestSample.Tests.UnitTests
 {
     public class DataAccessLayerTest
     {
+        [Theory]
+        [InlineData(150, true)]
+        [InlineData(199, true)]
+        [InlineData(200, true)]
+        [InlineData(201, true)]
+        [InlineData(249, true)]
+        [InlineData(250, true)]
+        [InlineData(251, false)]
+        [InlineData(300, false)]
+        
+        public async Task AddMessageAsync_TestMessageLength(int messageLength, bool expectedValidMessage)
+        {
+            using (var db = new AppDbContext(Utilities.TestDbContextOptions()))
+            {
+                // Arrange
+                var recId = 10;
+                var expectedMessage = new Message() { Id = recId, Text = new string('X', messageLength) };
+                
+                // Act
+                var isValidMessage = Validator.TryValidateObject(expectedMessage, new ValidationContext(expectedMessage), null, validateAllProperties: true);
+                
+                // Assert
+                Assert.Equal(expectedValidMessage, isValidMessage);
+            }
+        }
+        
         [Fact]
         public async Task GetMessagesAsync_MessagesAreReturned()
         {


### PR DESCRIPTION
This pull request introduces a new unit test to the `DataAccessLayerTest` class to validate the length of messages in the `AddMessageAsync` method. The test uses a parameterized approach to check various message lengths for validity.

### New Unit Test Addition:

* [`src/Application/tests/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.cs`](diffhunk://#diff-759cd6dbf2cedcb026f64771a32e9837bd979c7b48a52cae4dbd208ece5a69b4R7-R38): Added a new `[Theory]` test method `AddMessageAsync_TestMessageLength` to validate message lengths using `Validator.TryValidateObject`. This test ensures that messages of different lengths are correctly identified as valid or invalid based on predefined criteria.